### PR TITLE
index,test: support browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,1 @@
-module.exports = process.env.eql_COV
-  ? require('./lib-cov/eql')
-  : require('./lib/eql');
+module.exports = require('./lib/eql');

--- a/test/bootstrap/index.js
+++ b/test/bootstrap/index.js
@@ -8,4 +8,6 @@ global.assert = require('simple-assert');
  * Import project
  */
 
-global.eql = require('../..');
+global.eql = process.env.type_COV
+  ? require('../../lib-cov/eql')
+  : require('../../lib/eql');


### PR DESCRIPTION
Move the conditional require from /index.js to /test/bootstrap/index.js.

This allows browserify to process the module and makes the code more compliant
with upcoming ES6 modules.

Closes #1.
