### PR TITLE
Update dependency type-detect

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,5 +16,6 @@ module.exports = function(config) {
     , browsers: [ 'PhantomJS' ]
     , captureTimeout: 60000
     , singleRun: false
+    , plugins : [ 'karma-mocha', 'karma-phantomjs-launcher' ]
   });
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
       , "karma": "*"
       , "karma-cli": "*"
       , "karma-mocha": "*"
+      , "karma-phantomjs-launcher": "*"
       , "mocha": "*"
       , "mocha-lcov-reporter": "0.0.1"
       , "simple-assert": "*"


### PR DESCRIPTION
I'm developing something dependent on `chai`, which depends on `deep-eql`, having an outdated dependency. This should not break anything and makes me happy :)
