### PR TITLE
upgraded type-detect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-    "name": "deep-eql"
-  , "version": "0.1.3"
-  , "description": "Improved deep equality testing for Node.js and the browser."
-  , "author": "Jake Luer <jake@alogicalparadox.com>"
-  , "license": "MIT"
-  , "keywords": [
-        "deep equal"
-      , "object equal"
-      , "testing"
-      , "chai util"
-    ]
-  , "repository": {
-        "type": "git"
-      , "url": "git@github.com:chaijs/deep-eql.git"
-    }
-  , "engines": {
-      "node": "*"
-    }
-  , "main": "./index"
-  , "scripts": {
-      "test": "make test"
-    }
-  , "dependencies": {
-        "type-detect": "0.1.2"
-    }
-  , "devDependencies": {
-        "component": "*"
-      , "coveralls": "2.0.16"
-      , "jscoverage": "0.3.7"
-      , "karma": "*"
-      , "karma-cli": "*"
-      , "karma-mocha": "*"
-      , "karma-phantomjs-launcher": "*"
-      , "mocha": "*"
-      , "mocha-lcov-reporter": "0.0.1"
-      , "simple-assert": "*"
-    }
+  "name": "deep-eql",
+  "version": "0.1.3",
+  "description": "Improved deep equality testing for Node.js and the browser.",
+  "author": "Jake Luer <jake@alogicalparadox.com>",
+  "license": "MIT",
+  "keywords": [
+    "deep equal",
+    "object equal",
+    "testing",
+    "chai util"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:chaijs/deep-eql.git"
+  },
+  "engines": {
+    "node": "*"
+  },
+  "main": "./index",
+  "scripts": {
+    "test": "make test"
+  },
+  "dependencies": {
+    "type-detect": "^1.0.0"
+  },
+  "devDependencies": {
+    "component": "*",
+    "coveralls": "2.0.16",
+    "jscoverage": "0.3.7",
+    "karma": "*",
+    "karma-cli": "*",
+    "karma-mocha": "*",
+    "karma-phantomjs-launcher": "*",
+    "mocha": "*",
+    "mocha-lcov-reporter": "0.0.1",
+    "simple-assert": "*"
+  }
 }


### PR DESCRIPTION
Hi! After installing  chai, I noticed.
chai@3.5.0 
  ├── assertion-error@1.0.1 
  ├─┬ deep-eql@0.1.3 
  │ └── type-detect@0.1.1 
  └── type-detect@1.0.0  