### PR TITLE
"tolerance" option

### DIFF
--- a/lib/eql.js
+++ b/lib/eql.js
@@ -51,7 +51,12 @@ module.exports = deepEqual;
  * @return {Boolean} equal match
  */
 
-function deepEqual(a, b, m) {
+function deepEqual(a, b, m, options) {
+  if (type(m) === 'object') {
+    options = m;
+    m = undefined;
+  }
+
   if (sameValue(a, b)) {
     return true;
   } else if ('date' === type(a)) {
@@ -61,14 +66,14 @@ function deepEqual(a, b, m) {
   } else if (Buffer.isBuffer(a)) {
     return bufferEqual(a, b);
   } else if ('arguments' === type(a)) {
-    return argumentsEqual(a, b, m);
+    return argumentsEqual(a, b, m, options);
   } else if (!typeEqual(a, b)) {
     return false;
   } else if (('object' !== type(a) && 'object' !== type(b))
   && ('array' !== type(a) && 'array' !== type(b))) {
     return sameValue(a, b);
   } else {
-    return objectEqual(a, b, m);
+    return objectEqual(a, b, m, options);
   }
 }
 
@@ -140,11 +145,11 @@ function regexpEqual(a, b) {
  * @return {Boolean} result
  */
 
-function argumentsEqual(a, b, m) {
+function argumentsEqual(a, b, m, options) {
   if ('arguments' !== type(b)) return false;
   a = [].slice.call(a);
   b = [].slice.call(b);
-  return deepEqual(a, b, m);
+  return deepEqual(a, b, m, options);
 }
 
 /*!
@@ -222,7 +227,7 @@ function isValue(a) {
  * @return {Boolean} result
  */
 
-function objectEqual(a, b, m) {
+function objectEqual(a, b, m, options) {
   if (!isValue(a) || !isValue(b)) {
     return false;
   }
@@ -262,7 +267,7 @@ function objectEqual(a, b, m) {
   var key;
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
-    if (!deepEqual(a[key], b[key], m)) {
+    if (!deepEqual(a[key], b[key], m, options)) {
       return false;
     }
   }

--- a/lib/eql.js
+++ b/lib/eql.js
@@ -61,6 +61,8 @@ function deepEqual(a, b, m, options) {
     return true;
   } else if ('date' === type(a)) {
     return dateEqual(a, b);
+  } else if ('number' === type(a) && 'number' === type(b)) {
+    return numberEqual(a, b, options);
   } else if ('regexp' === type(a)) {
     return regexpEqual(a, b);
   } else if (Buffer.isBuffer(a)) {
@@ -118,6 +120,26 @@ function typeEqual(a, b) {
 function dateEqual(a, b) {
   if ('date' !== type(b)) return false;
   return sameValue(a.getTime(), b.getTime());
+}
+
+/*!
+ * Compare two numbers via `sameValue` or with tolerance
+ * if the `tolerance` option is set.
+ *
+ * @param {Mixed} a
+ * @param {Mixed} b
+ * @return {Boolean} equal match
+ */
+
+function numberEqual(a, b, options) {
+  if (options && options.tolerance) {
+
+    var acceptableDiff = Math.abs(options.tolerance * b);
+    return Math.abs(b - a) <= acceptableDiff;
+
+  } else {
+    return sameValue(a, b);
+  }
 }
 
 /*!

--- a/test/eql.js
+++ b/test/eql.js
@@ -74,6 +74,13 @@ tests.push([ 'eql({ foo: "bar" }, { foo: "baz" })', { foo: 'bar' }, { foo: 'baz'
 tests.push([ 'eql({ foo: { bar: "foo" }}, { foo: { bar: "baz" }})', { foo: { bar: 'foo' }}, { foo: { bar: 'baz' }}, true ]);
 
 /*!
+ * Tolerance
+ */
+
+tests.push([ 'eql([ 1, 2, 3 ], [ 1.001, 2, 3 ], { tolerance: 0.001 })', [ 1, 2, 3 ], [ 1.001, 2, 3 ], false, { tolerance: 0.001 } ]);
+tests.push([ 'eql([ 1, 2, 3 ], [ 1.01, 2, 3 ], { tolerance: 0.001 })', [ 1, 2, 3 ], [ 1.01, 2, 3 ], true, { tolerance: 0.001 } ]);
+
+/*!
  * Test setup
  */
 

--- a/test/eql.js
+++ b/test/eql.js
@@ -86,9 +86,9 @@ describe('deep-equal', function() {
 
     it(title, function() {
       if (negate) {
-        assert(!eql(test[1], test[2]));
+        assert(!eql(test[1], test[2], test[4]));
       } else {
-        assert(eql(test[1], test[2]));
+        assert(eql(test[1], test[2], test[4]));
       }
     });
   });


### PR DESCRIPTION
As described in https://github.com/chaijs/chai/issues/709 I need some way to specify a tolerance percentage when comparing numbers. Feel free to reject this proposal if you have a better solution in progress. I guess `addProperty('roughly')`, `overwriteMethod('eql')` and this branch will result in what I need for now.