### PR TITLE
Empty arrays with different lengths should not be equal.

### DIFF
--- a/lib/eql.js
+++ b/lib/eql.js
@@ -62,13 +62,14 @@ function deepEqual(a, b, m) {
     return bufferEqual(a, b);
   } else if ('arguments' === type(a)) {
     return argumentsEqual(a, b, m);
+  } else if ('array' === type(a)) {
+    return arrayEqual(a, b, m);
   } else if (!typeEqual(a, b)) {
     return false;
-  } else if (('object' !== type(a) && 'object' !== type(b))
-  && ('array' !== type(a) && 'array' !== type(b))) {
-    return sameValue(a, b);
-  } else {
+  } else if ('object' === type(a)) {
     return objectEqual(a, b, m);
+  } else {
+    return sameValue(a, b);
   }
 }
 
@@ -144,6 +145,23 @@ function argumentsEqual(a, b, m) {
   if ('arguments' !== type(b)) return false;
   a = [].slice.call(a);
   b = [].slice.call(b);
+  return deepEqual(a, b, m);
+}
+
+/*!
+ * Assert deep equality of two arrays. This is the same as comparing two
+ * objects, but the arrays must also have the same length. The `length`
+ * property is non-enumerable, so it is missed by `objectEqual()`.
+ *
+ * @param {Arguments} a
+ * @param {Arguments} b
+ * @param {Array} memoize (optional)
+ * @return {Boolean} result
+ */
+
+function arrayEqual(a, b, m) {
+  if ('array' !== type(b)) return false;
+  if (a.length !== b.length) return false;
   return deepEqual(a, b, m);
 }
 

--- a/lib/eql.js
+++ b/lib/eql.js
@@ -162,7 +162,7 @@ function argumentsEqual(a, b, m) {
 function arrayEqual(a, b, m) {
   if ('array' !== type(b)) return false;
   if (a.length !== b.length) return false;
-  return deepEqual(a, b, m);
+  return objectEqual(a, b, m);
 }
 
 /*!

--- a/test/eql.js
+++ b/test/eql.js
@@ -68,6 +68,7 @@ tests.push([ 'eql(/\\\s/g, /\\\[/g)', /\s/g, /\[/g, true ]);
 
 tests.push([ 'eql([ 1, 2, 3 ], [ 1, 2, 3 ])', [ 1, 2, 3 ], [ 1, 2, 3 ] ]);
 tests.push([ 'eql([ 3, 2, 1 ], [ 1, 2, 3 ])', [ 3, 2, 1 ], [ 1, 2, 3 ], true ]);
+tests.push([ 'eql(new Array(5), new Array(99))', new Array(5), new Array(99), true ]);
 
 tests.push([ 'eql({ a: 1, b: 2, c: 3}, { a: 1, b: 2, c: 3 })', { a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 } ]);
 tests.push([ 'eql({ foo: "bar" }, { foo: "baz" })', { foo: 'bar' }, { foo: 'baz' }, true ]);


### PR DESCRIPTION
Empty arrays with different lengths are considered equal right now. This pull request fixes that.
```js
var eql = require('deep-eql');

eql(new Array(5), new Array(99)); // This incorrectly evaluates to `true`
```