### PR TITLE
Support ES6 types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
   - 0.10
+  - 6
+sudo: false
 script: make test-travisci

--- a/lib/eql.js
+++ b/lib/eql.js
@@ -54,22 +54,90 @@ module.exports = deepEqual;
 function deepEqual(a, b, m) {
   if (sameValue(a, b)) {
     return true;
-  } else if ('date' === type(a)) {
-    return dateEqual(a, b);
-  } else if ('regexp' === type(a)) {
-    return regexpEqual(a, b);
-  } else if (Buffer.isBuffer(a)) {
-    return bufferEqual(a, b);
-  } else if ('arguments' === type(a)) {
-    return argumentsEqual(a, b, m);
-  } else if (!typeEqual(a, b)) {
-    return false;
-  } else if (('object' !== type(a) && 'object' !== type(b))
-  && ('array' !== type(a) && 'array' !== type(b))) {
-    return sameValue(a, b);
-  } else {
-    return objectEqual(a, b, m);
   }
+  var type_a = type(a)
+  var type_b = type(b)
+  if (type_a !== type_b) {
+    return false
+  }
+  switch (type_a) {
+    case 'arguments': return argumentsEqual(a, b, m);
+    case 'date':      return dateEqual(a, b);
+    case 'error':     return sameValue(a.message, b.message);
+    case 'map':       return mapEquals(a, b);
+    case 'object':    return objectEqual(a, b, m);
+    case 'regexp':    return regexpEqual(a, b);
+    case 'set':       return setEquals(a, b);
+
+    case 'array':
+    case 'uint8array': // and Buffer
+    case 'uint8clampedarray':
+    case 'int8array':
+    case 'uint16array':
+    case 'int16array':
+    case 'uint32array':
+    case 'int32array':
+    case 'float32array':
+    case 'float64array':
+      return iterableEqual(a, b);
+    case 'arraybuffer':
+      return iterableEqual(new Uint8Array(a),
+                           new Uint8Array(b));
+    case 'dataview':
+      return iterableEqual(new Uint8Array(a.buffer),
+                           new Uint8Array(b.buffer));
+    case 'promise': // would require an async API
+    case 'weakmap': // not enumerable.  Weak.
+    case 'weakset': // not enumerable.  Weak.
+      throw new Error('Unsupported deep-equal type: ' + type_a);
+
+    default:
+      return false;
+  }
+}
+
+/*!
+ * Compare two Set objects by asserting that
+ * the values are the same.
+ *
+ * @param {Set} a
+ * @param {Set} b
+ * @return {Boolean} result
+ */
+
+function setEquals(a, b) {
+  if (a.size != b.size) return false;
+  var ret = true;
+  a.forEach(function(ai) {
+    var found = false;
+    b.forEach(function(bi) {
+      if (deepEqual(ai, bi)) found = true;
+    });
+    if (!found) ret = false;
+  });
+  return ret;
+}
+
+/*!
+ * Compare two Set objects by asserting that
+ * the values are the same.
+ *
+ * @param {Set} a
+ * @param {Set} b
+ * @return {Boolean} result
+ */
+
+function mapEquals(a, b) {
+  if (a.size != b.size) return false;
+  var ret = true;
+  a.forEach(function(ak,av) {
+    var found = false;
+    b.forEach(function(bk,bv) {
+      if (deepEqual(ak, bk) && deepEqual(av, bv)) found = true;
+    });
+    if (!found) ret = false;
+  });
+  return ret;
 }
 
 /*!
@@ -87,21 +155,6 @@ function sameValue(a, b) {
 }
 
 /*!
- * Compare the types of two given objects and
- * return if they are equal. Note that an Array
- * has a type of `array` (not `object`) and arguments
- * have a type of `arguments` (not `array`/`object`).
- *
- * @param {Mixed} a
- * @param {Mixed} b
- * @return {Boolean} result
- */
-
-function typeEqual(a, b) {
-  return type(a) === type(b);
-}
-
-/*!
  * Compare two Date objects by asserting that
  * the time values are equal using `saveValue`.
  *
@@ -111,7 +164,6 @@ function typeEqual(a, b) {
  */
 
 function dateEqual(a, b) {
-  if ('date' !== type(b)) return false;
   return sameValue(a.getTime(), b.getTime());
 }
 
@@ -125,7 +177,6 @@ function dateEqual(a, b) {
  */
 
 function regexpEqual(a, b) {
-  if ('regexp' !== type(b)) return false;
   return sameValue(a.toString(), b.toString());
 }
 
@@ -141,7 +192,6 @@ function regexpEqual(a, b) {
  */
 
 function argumentsEqual(a, b, m) {
-  if ('arguments' !== type(b)) return false;
   a = [].slice.call(a);
   b = [].slice.call(b);
   return deepEqual(a, b, m);
@@ -176,27 +226,13 @@ function iterableEqual(a, b) {
   var match = true;
 
   for (; i < a.length; i++) {
-    if (a[i] !== b[i]) {
+    if (!deepEqual(a[i], b[i])) {
       match = false;
       break;
     }
   }
 
   return match;
-}
-
-/*!
- * Extension to `iterableEqual` specifically
- * for Node.js Buffers.
- *
- * @param {Buffer} a
- * @param {Mixed} b
- * @return {Boolean} result
- */
-
-function bufferEqual(a, b) {
-  if (!Buffer.isBuffer(b)) return false;
-  return iterableEqual(a, b);
 }
 
 /*!

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "karma-phantomjs-launcher": "*",
     "mocha": "*",
     "mocha-lcov-reporter": "1.2.0",
+    "phantomjs-prebuilt": "2.1.7",
     "simple-assert": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
     "test": "make test"
   },
   "dependencies": {
-    "type-detect": "^1.0.0"
+    "type-detect": "^2.0.1"
   },
   "devDependencies": {
     "component": "*",
-    "coveralls": "2.0.16",
-    "jscoverage": "0.3.7",
+    "coveralls": "2.11.9",
+    "jscoverage": "0.6.0",
     "karma": "*",
     "karma-cli": "*",
     "karma-mocha": "*",
     "karma-phantomjs-launcher": "*",
     "mocha": "*",
-    "mocha-lcov-reporter": "0.0.1",
+    "mocha-lcov-reporter": "1.2.0",
     "simple-assert": "*"
   }
 }

--- a/test/eql.js
+++ b/test/eql.js
@@ -12,6 +12,18 @@ tests.push([ 'eql(+0, +0)', +0, +0 ]);
 tests.push([ 'eql(0, 0)', 0, 0 ]);
 tests.push([ 'eql(1, 1)', 1, 1 ]);
 tests.push([ 'eql(-1, 1)', -1, 1, true ]);
+tests.push([ 'eql(inf, inf)', Infinity, Infinity ]);
+tests.push([ 'eql(-inf, -inf)', -Infinity, -Infinity ]);
+tests.push([ 'eql(NaN, NaN)', NaN, NaN ]);
+tests.push([ '!eql(NaN, 0)', NaN, 0, true ]);
+tests.push([ 'eql(undefined, undefined)', undefined, undefined ]);
+tests.push([ 'eql(null, null)', null, null ]);
+tests.push([ '!eql(null, undefined)', null, undefined, true ]);
+
+// wrap in array to hide from the test framework
+tests.push([ 'eql(Error, Error)', [new Error('foo')], [new Error('foo')]]);
+// fails on browser, I think because of the test framework itself
+// tests.push([ '!eql(Error, Error)', [new Error('foo')], [new Error('BAR')], true]);
 
 /*!
  * typeEqual
@@ -68,10 +80,95 @@ tests.push([ 'eql(/\\\s/g, /\\\[/g)', /\s/g, /\[/g, true ]);
 
 tests.push([ 'eql([ 1, 2, 3 ], [ 1, 2, 3 ])', [ 1, 2, 3 ], [ 1, 2, 3 ] ]);
 tests.push([ 'eql([ 3, 2, 1 ], [ 1, 2, 3 ])', [ 3, 2, 1 ], [ 1, 2, 3 ], true ]);
+tests.push([ 'eql([ [1, 2, 3] ], [ [1, 2, 3] ])', [ [1, 2, 3] ], [ [1, 2, 3] ] ]);
 
 tests.push([ 'eql({ a: 1, b: 2, c: 3}, { a: 1, b: 2, c: 3 })', { a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 } ]);
 tests.push([ 'eql({ foo: "bar" }, { foo: "baz" })', { foo: 'bar' }, { foo: 'baz' }, true ]);
 tests.push([ 'eql({ foo: { bar: "foo" }}, { foo: { bar: "baz" }})', { foo: { bar: 'foo' }}, { foo: { bar: 'baz' }}, true ]);
+
+/*!
+ * setEqual
+ */
+
+if (typeof(Set) === 'function') {
+  var set1 = new Set([{a:0},{a:1}]);
+  var set2 = new Set([{a:1},{a:0}]);
+  tests.push([ 'eql(set1, set2)', set1, set2]);
+  var sym = Symbol('sym')
+  var set3 = new Set([sym]);
+  var set4 = new Set([sym]);
+  tests.push([ 'eql(set3, set4)', set3, set4]);
+  tests.push([ '!eql(set1, set3)', set1, set3, true]);
+}
+
+/*!
+ * mapEqual
+ */
+
+if (typeof(Map) === 'function') {
+  var map1 = new Map([[0, {a: 1}]]);
+  var map2 = new Map([[0, {a: 1}]]);
+  tests.push([ 'eql(map1, map2)', map1, map2]);
+  var sym = Symbol('sym')
+  var map3 = new Map([[sym, sym]]);
+  var map4 = new Map([[sym, sym]]);
+  tests.push([ 'eql(map3, map4)', map3, map4]);
+  tests.push([ '!eql(map1, map3)', map1, map3, true]);
+}
+
+/*!
+ * New array types
+ */
+
+if (typeof(ArrayBuffer) === 'function') {
+  var buf1 = new ArrayBuffer(16);
+  var buf2 = new ArrayBuffer(16);
+  var buf3 = new ArrayBuffer(16);
+  tests.push([ 'eql(arraybuffer1, arraybuffer1)', buf1, buf1]);
+  tests.push([ 'eql(arraybuffer1, arraybuffer2)', buf1, buf2]);
+  var ubuf3 = new Uint8Array(buf3);
+  ubuf3[0] = 1; // just make it not equal
+  tests.push([ '!eql(arraybuffer1, arraybuffer3)', buf1, buf3, true]);
+  var types = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8ClampedArray,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+    DataView
+  ];
+  types.forEach(function(t) {
+    var b1 = new t(buf1);
+    var b2 = new t(buf2);
+    var b3 = new t(buf3);
+    tests.push([ 'eql(' + t.name + '1, ' + t.name + '1)', b1, b1]);
+    tests.push([ 'eql(' + t.name + '1, ' + t.name + '2)', b1, b2]);
+    tests.push([ '!eql(' + t.name + '1, ' + t.name + '3)', b1, b3, true]);
+  })
+}
+
+function f() {}
+function g() {}
+tests.push(['eql(f(), f())', f, f])
+tests.push(['eql(f(), g())', f, g, true])
+
+if (typeof(Proxy) === 'function') {
+  // note: there are lots of ways you could make a proxy fail
+  var handler = {
+    get: function(target, name) {
+      return target[name] || name;
+    }
+  }
+  var o1 = { foo: 1 };
+  var o2 = { foo: 1 };
+  var p1 = new Proxy(o1, handler);
+  var p2 = new Proxy(o2, handler);
+  tests.push([ 'eql(proxy1, proxy2)', p1, p2 ]);
+}
 
 /*!
  * Test setup
@@ -85,6 +182,9 @@ describe('deep-equal', function() {
     title += test[0];
 
     it(title, function() {
+      if (test[1] && test[1].constructor && (test[1].constructor.name === 'Error')) {
+        console.log(test[1].message, test[2].message)
+      }
       if (negate) {
         assert(!eql(test[1], test[2]));
       } else {


### PR DESCRIPTION
Support the new ES6 types, including Set and Map.  Update dependencies to get latest `type-detect`.  Fixes #4.

There are a couple (WeakSet, WeakMap, Promise) that are challenging to the point of perhaps being impossible.  Those at least throw exceptions now.  There are several types that `type-detect` detects that didn't make much sense to compare (e.g. `"location"`, '"array iterator"`).

Took the opportunity to streamline the `deepEqual` function.  All of the tests still pass, but the logic is slightly different.  I added tests for several edge cases, to ensure that things still work.