### PR TITLE
fix: treat circular objects and sets as equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,8 +178,8 @@ function extensiveDeepEqual(leftHandOperand, rightHandOperand, options) {
   }
 
   // Temporarily set the operands in the memoize object to prevent blowing the stack
-  memoizeSet(leftHandOperand, rightHandOperand, options.memoize, false);
-  memoizeSet(rightHandOperand, leftHandOperand, options.memoize, false);
+  memoizeSet(leftHandOperand, rightHandOperand, options.memoize, true);
+  memoizeSet(rightHandOperand, leftHandOperand, options.memoize, true);
 
   var result = extensiveDeepEqualByType(leftHandOperand, rightHandOperand, leftHandType, options);
   memoizeSet(leftHandOperand, rightHandOperand, options.memoize, result);

--- a/test/index.js
+++ b/test/index.js
@@ -297,13 +297,13 @@ describe('Generic', function () {
       assert(eql({ foo: 'bar' }, { bar: 'baz' }) === false, 'eql({ foo: "bar" }, { foo: "baz" }) === false');
     });
 
-    it('returns false with recursive objects of differing values', function () {
+    it('returns true with circular objects', function () {
       var objectA = { foo: 1 };
       var objectB = { foo: 1 };
       objectA.bar = objectB;
       objectB.bar = objectA;
-      assert(eql(objectA, objectB) === false,
-        'eql({ foo: 1, bar: -> }, { foo: 1, bar: <- }) === false');
+      assert(eql(objectA, objectB) === true,
+        'eql({ foo: 1, bar: -> }, { foo: 1, bar: <- }) === true');
     });
 
   });

--- a/test/new-ecmascript-types.js
+++ b/test/new-ecmascript-types.js
@@ -231,12 +231,12 @@ describe('ES2015 Specific', function () {
       assert(eql(setA, setB) === false, 'eql(Set { "a", "b", "c" }, Set { "d", "e", "f" }) === false');
     });
 
-    it('returns false for Sets with different circular references', function () {
+    it('returns true for circular Sets', function () {
       var setA = new Set();
       var setB = new Set();
       setA.add(setB);
       setB.add(setA);
-      assert(eql(setA, setB) === false, 'eql(Set { -> }, Set { <- }) === false');
+      assert(eql(setA, setB) === true, 'eql(Set { -> }, Set { <- }) === true');
     });
 
   });


### PR DESCRIPTION
- The v1.0.0 refactor created a breaking change by treating two objects
  as unequal when each object's only property is the other object. This
  fix reverts the behavior so that such objects are considered equal.