### PR TITLE
fix: handle buffers in Node v0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -405,6 +405,13 @@ function keysEqual(leftHandOperand, rightHandOperand, keys, options) {
  */
 
 function objectEqual(leftHandOperand, rightHandOperand, options) {
+  // This block can be removed once support for Node v0.10 is dropped because
+  // buffers are properly detected as iterables in later versions.
+  if (typeof Buffer === 'function' &&
+      typeof Buffer.isBuffer === 'function' &&
+      Buffer.isBuffer(leftHandOperand)) {
+    return iterableEqual(leftHandOperand, rightHandOperand, options);
+  }
   var leftHandKeys = getEnumerableKeys(leftHandOperand);
   var rightHandKeys = getEnumerableKeys(rightHandOperand);
   if (leftHandKeys.length && leftHandKeys.length === rightHandKeys.length) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,9 @@
 var assert = require('simple-assert');
 var eql = require('..');
 var MemoizeMap = require('..').MemoizeMap;
+function describeIf(condition) {
+  return condition ? describe : describe.skip;
+}
 describe('Generic', function () {
 
   describe('strings', function () {
@@ -358,6 +361,24 @@ describe('Generic', function () {
     it('returns false for different errors', function () {
       assert(eql(new Error('foo'), new Error('foo')) === false,
         'eql(new Error("foo"), new Error("foo")) === false');
+    });
+
+  });
+
+});
+
+describe('Node Specific', function () {
+
+  describeIf(typeof Buffer === 'function')('buffers', function () {
+
+    it('returns true for same buffers', function () {
+      assert(eql(new Buffer([ 1 ]), new Buffer([ 1 ])) === true,
+        'eql(new Buffer([ 1 ]), new Buffer([ 1 ])) === true');
+    });
+
+    it('returns false for different buffers', function () {
+      assert(eql(new Buffer([ 1 ]), new Buffer([ 2 ])) === false,
+        'eql(new Buffer([ 1 ]), new Buffer([ 2 ])) === false');
     });
 
   });


### PR DESCRIPTION
- The v1.0.0 refactor introduced a bug with handling equality comparisons
  of buffers in Node v0.10. In later versions of Node, buffers are
  correctly detected as iterables, but in Node v0.10 they are
  incorrectly detected as plain objects, leading to erroneous results.
  This fix adds support for buffers in Node v0.10 via `Buffer.isBuffer`.
  The logic added by this fix can safely be removed once support for
  Node v0.10 is dropped, but the new tests should be kept.