### PR TITLE
chore: drop support for Node v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   directories:
   - node_modules
 node_js:
- - 0.10 # to be removed 2016-10-31
  - 0.12 # to be removed 2016-12-31
  - 4 # to be removed 2018-04-01
  - 6 # to be removed 2019-04-01

--- a/index.js
+++ b/index.js
@@ -405,13 +405,6 @@ function keysEqual(leftHandOperand, rightHandOperand, keys, options) {
  */
 
 function objectEqual(leftHandOperand, rightHandOperand, options) {
-  // This block can be removed once support for Node v0.10 is dropped because
-  // buffers are properly detected as iterables in later versions.
-  if (typeof Buffer === 'function' &&
-      typeof Buffer.isBuffer === 'function' &&
-      Buffer.isBuffer(leftHandOperand)) {
-    return iterableEqual(leftHandOperand, rightHandOperand, options);
-  }
   var leftHandKeys = getEnumerableKeys(leftHandOperand);
   var rightHandKeys = getEnumerableKeys(rightHandOperand);
   if (leftHandKeys.length && leftHandKeys.length === rightHandKeys.length) {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "watchify": "^3.7.0"
   },
   "engines": {
-    "node": "*"
+    "node": ">=0.12"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Node v0.10 is no longer supported.