### PR TITLE
fix: Fix WeakMap set error, arg order irregularities

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -76,6 +76,10 @@ describe('Generic', function () {
       assert(eql(null, undefined) === false, 'eql(null, undefined) === false');
     });
 
+    it('doesn\'t crash on weakmap key error (#33)', function () {
+      assert(eql({}, null) === false, 'eql({}, null) === false');
+    });
+
   });
 
   describe('undefined', function () {
@@ -469,6 +473,17 @@ describe('Comparator', function () {
     var valueB = { a: 1 };
     assert(eql(valueA, valueB, { comparator: matcherComparator }) === true,
       'eql({a:value => typeof value === "number"}, {a:1}, <comparator>) === true');
+  });
+
+  it('returns true if Comparator says so even on primitives (switch arg order)', function () {
+    var valueA = { a: 1 };
+    var valueB = {
+      a: new Matcher(function (value) {
+        return typeof value === 'number';
+      }),
+    };
+    assert(eql(valueA, valueB, { comparator: matcherComparator }) === true,
+      'eql({a:1}, {a:value => typeof value === "number"}, <comparator>) === true');
   });
 
   it('returns true if Comparator says so (deep-equality)', function () {


### PR DESCRIPTION
Contains a minor speed boost as well and helps comparators override all behavior, including primitive (simple) tests.

This fixes issue #33 and #34.

The full changes:

* Extracted the simple equality check into its own function.
* Checked both left & right-hand side for primitive value;
* Removed `undefined` check in simple equality check (`typeof undefined === 'undefined'`)
* Removed extra `memoizeSet` calls; just check both sides if memoized. This should save some allocations
* Added test for comparator inconsistency with argument order (#34)

It appears extracting the simple check helps V8 optimize slightly; I'm seeing above 25% better performance:

```
Before:

> deep-eql@ bench /Users/samuelreed/git/forks/deep-eql
> node bench

equal references                     x 41,650,796 ops/sec ±1.15% (85 runs sampled)
string literal                       x 42,529,320 ops/sec ±0.94% (83 runs sampled)
array literal                        x 969,484 ops/sec ±1.21% (84 runs sampled)
boolean literal                      x 37,699,924 ops/sec ±1.08% (85 runs sampled)
object literal                       x 341,713 ops/sec ±1.14% (86 runs sampled)
object from null                     x 617,673 ops/sec ±1.23% (84 runs sampled)
regex literal                        x 655,612 ops/sec ±1.11% (86 runs sampled)
number literal                       x 38,482,461 ops/sec ±1.00% (87 runs sampled)
null                                 x 38,562,104 ops/sec ±1.06% (84 runs sampled)
undefined                            x 42,666,572 ops/sec ±0.97% (86 runs sampled)
buffer                               x 807,656 ops/sec ±1.28% (87 runs sampled)
date                                 x 697,190 ops/sec ±1.32% (84 runs sampled)
map                                  x 242,114 ops/sec ±1.40% (83 runs sampled)
map (complex)                        x 114,936 ops/sec ±1.30% (87 runs sampled)
regex constructor                    x 621,738 ops/sec ±1.16% (87 runs sampled)
set                                  x 243,301 ops/sec ±1.08% (85 runs sampled)
string constructor                   x 334,962 ops/sec ±1.35% (86 runs sampled)
arguments                            x 394,289 ops/sec ±1.34% (84 runs sampled)
string literal (differing)           x 33,795,367 ops/sec ±0.93% (85 runs sampled)
array literal (differing)            x 912,899 ops/sec ±1.24% (87 runs sampled)
boolean literal (differing)          x 31,620,990 ops/sec ±1.30% (82 runs sampled)
object literal (differing)           x 316,401 ops/sec ±2.23% (82 runs sampled)
regex literal (differing)            x 613,603 ops/sec ±1.52% (86 runs sampled)
number literal (differing)           x 38,386,417 ops/sec ±1.11% (81 runs sampled)
null & undefined                     x 32,770,210 ops/sec ±1.15% (85 runs sampled)
buffer (differing)                   x 866,638 ops/sec ±1.95% (83 runs sampled)
date (differing)                     x 644,873 ops/sec ±2.92% (82 runs sampled)
error                                x 397,043 ops/sec ±2.15% (82 runs sampled)
map (differing)                      x 180,868 ops/sec ±2.95% (81 runs sampled)
regex ctor (differing)               x 460,153 ops/sec ±5.96% (69 runs sampled)
set (differing)                      x 78,847 ops/sec ±14.43% (65 runs sampled)
string ctor (differing)              x 98,389 ops/sec ±10.04% (34 runs sampled)
weakmap                              x 204,063 ops/sec ±8.23% (42 runs sampled)
weakset                              x 724,277 ops/sec ±9.25% (52 runs sampled)
arguments (differing)                x 154,083 ops/sec ±7.00% (57 runs sampled)
function                             x 24,055,280 ops/sec ±7.74% (59 runs sampled)
promise                              x 957,871 ops/sec ±6.53% (70 runs sampled)
arrow function (differing)           x 29,528,495 ops/sec ±1.38% (83 runs sampled)
generator func (differing)           x 30,243,433 ops/sec ±2.31% (79 runs sampled)
~Fin~

------

After:

> deep-eql@ bench /Users/samuelreed/git/forks/deep-eql
> node bench

equal references                     x 52,031,409 ops/sec ±1.08% (84 runs sampled)
string literal                       x 44,485,598 ops/sec ±0.99% (86 runs sampled)
array literal                        x 1,392,710 ops/sec ±1.71% (84 runs sampled)
boolean literal                      x 46,953,465 ops/sec ±1.15% (85 runs sampled)
object literal                       x 350,010 ops/sec ±1.87% (84 runs sampled)
object from null                     x 665,775 ops/sec ±1.68% (86 runs sampled)
regex literal                        x 743,766 ops/sec ±1.38% (82 runs sampled)
number literal                       x 47,048,671 ops/sec ±1.26% (83 runs sampled)
null                                 x 44,050,732 ops/sec ±1.36% (83 runs sampled)
undefined                            x 46,967,993 ops/sec ±1.13% (83 runs sampled)
buffer                               x 976,960 ops/sec ±1.55% (85 runs sampled)
date                                 x 880,766 ops/sec ±1.12% (85 runs sampled)
map                                  x 288,682 ops/sec ±1.44% (86 runs sampled)
map (complex)                        x 142,506 ops/sec ±1.79% (81 runs sampled)
regex constructor                    x 768,992 ops/sec ±1.59% (85 runs sampled)
set                                  x 318,478 ops/sec ±1.72% (79 runs sampled)
string constructor                   x 418,914 ops/sec ±1.45% (85 runs sampled)
arguments                            x 473,213 ops/sec ±1.25% (85 runs sampled)
string literal (differing)           x 42,933,813 ops/sec ±1.63% (85 runs sampled)
array literal (differing)            x 1,349,563 ops/sec ±1.67% (84 runs sampled)
boolean literal (differing)          x 37,283,579 ops/sec ±1.33% (83 runs sampled)
object literal (differing)           x 367,116 ops/sec ±1.64% (86 runs sampled)
regex literal (differing)            x 727,984 ops/sec ±1.36% (84 runs sampled)
number literal (differing)           x 46,512,104 ops/sec ±1.14% (84 runs sampled)
null & undefined                     x 35,049,946 ops/sec ±1.16% (86 runs sampled)
buffer (differing)                   x 1,006,815 ops/sec ±1.73% (83 runs sampled)
date (differing)                     x 818,149 ops/sec ±2.82% (85 runs sampled)
error                                x 454,657 ops/sec ±1.42% (83 runs sampled)
map (differing)                      x 313,785 ops/sec ±1.37% (84 runs sampled)
regex ctor (differing)               x 757,495 ops/sec ±1.47% (85 runs sampled)
set (differing)                      x 286,325 ops/sec ±1.97% (84 runs sampled)
string ctor (differing)              x 390,012 ops/sec ±1.70% (84 runs sampled)
weakmap                              x 1,320,313 ops/sec ±1.41% (87 runs sampled)
weakset                              x 1,503,973 ops/sec ±1.49% (82 runs sampled)
arguments (differing)                x 445,730 ops/sec ±1.16% (86 runs sampled)
function                             x 35,707,683 ops/sec ±0.90% (84 runs sampled)
promise                              x 1,337,815 ops/sec ±1.52% (85 runs sampled)
arrow function (differing)           x 43,479,682 ops/sec ±1.19% (84 runs sampled)
generator func (differing)           x 40,612,109 ops/sec ±0.90% (83 runs sampled)
~Fin~
```