### PR TITLE
Typo in build script for browserified file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "bench": "node bench",
-    "build": "browserify $npm_pakcage_main --standalone deepEqual -o deep-eql.js",
+    "build": "browserify $npm_package_main --standalone deepEqual -o deep-eql.js",
     "lint": "eslint --ignore-path .gitignore .",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",


### PR DESCRIPTION
Resulting in an empty deep-eql.js.
This calls for a patch release.