### PR TITLE
fix: check array's custom properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,6 +325,20 @@ function iterableEqual(leftHandOperand, rightHandOperand, options) {
       return false;
     }
   }
+
+  var leftHandProps = Object.keys(leftHandOperand);
+  var rightHandProps = Object.keys(rightHandOperand);
+  if (leftHandProps.length !== rightHandProps.length) {
+    return false;
+  }
+
+  for (var prop in rightHandProps) {
+    var propName = rightHandProps[prop];
+    if (deepEqual(leftHandOperand[propName], rightHandOperand[propName], options) === false) {
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -278,6 +278,24 @@ describe('Generic', function () {
       assert(eql(new Array(1), new Array(100)) === false, 'eql(new Array(1), new Array(100)) === false');
     });
 
+    it('returns true for arrays with the same custom properties', function () {
+      var one = [ 1, 2, 'str' ];
+      var two = [ 1, 2, 'str' ];
+      one.foo = 'bar';
+      two.foo = 'bar';
+
+      assert(eql(one, two), 'eql([ 0: 1, 1: 2, 2: "str", foo: "bar" ], [ 0: 1, 1: 2, 2: "str", foo: "bar" ])');
+    });
+
+    it('returns false for arrays with different custom properties', function () {
+      var one = [ 1, 2, 'str' ];
+      var two = [ 1, 2, 'str' ];
+      one.foo = 'bar';
+      two.foo = 'baz';
+
+      assert(eql(one, two) === false,
+        'eql([ 0: 1, 1: 2, 2: "str", foo: "bar" ], [ 0: 1, 1: 2, 2: "str", foo: "baz" ]) === false');
+    });
   });
 
   describe('objects', function () {


### PR DESCRIPTION
Hi folks!

While working on sinonjs/sinon#1322 I've found out that we're not checking for custom properties in arrays when doing deep equality on them.

While this might be considered a bad practice, it is indeed possible and more common that we'd like it to be, so this fix may come in handy.

Before this commit, two different arrays, like these ones, would yield false positives:

```js
var arrOne = [1, 2, 3]
arrOne.foo = 'bar'

var arrTwo = [1, 2, 3]
arrTwo.foo = 'baz'
```

Also, I didn't use [`getEnumerableKeys`](https://github.com/chaijs/deep-eql/compare/master...lucasfcosta:fix-check-array-with-custom-props?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR411) when [getting the Array's properties](https://github.com/chaijs/deep-eql/compare/master...lucasfcosta:fix-check-array-with-custom-props?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR329) because we don't want to check the Array prototype, because when dealing with Buffers or `TypedArrays`, they might have different offsets due to the fact of being binary data and this could cause problems. Especially when using `Buffer` itself.

If you don't mind I could add a check to avoid comparing the `offset` property on `TypedArrays` only so that we can compare the other properties in the array prototype, but I don't that would be productive.

I also added tests for this behavior.