### PR TITLE
Update type-detect dependency to v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   directories:
   - node_modules
 node_js:
- - 0.12 # to be removed 2016-12-31
  - 4 # to be removed 2018-04-01
  - 6 # to be removed 2019-04-01
  - lts/* # safety net; don't remove

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   },
   "dependencies": {
-    "type-detect": "^3.0.0"
+    "type-detect": "^4.0.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",


### PR DESCRIPTION
During a fresh install of `chai 4`, I noticed that type-detect was the only duplicated `node_modules/` package: chai directly depends on both `type-detect 4` and `deep-eql 2` (which in turn depends on `type-detect 3`). 

[type-detect@4.0.0](https://github.com/chaijs/type-detect) is 9 months old.  `deep-eql` can safely bump the dependency version in `package.json` (although I'm not sure if this should be considered a minor or major version number change for `deep-eql`). 

I wasn't sure if `component.json` should be updated, but since it hasn't been updated in 4 years I left it alone.  Maybe it should be deleted..?