### PR TITLE
perf: improve FakeMap implementation

### DIFF
--- a/bench/.eslintrc
+++ b/bench/.eslintrc
@@ -6,6 +6,7 @@
     "es6": true
   },
   "rules": {
+    "no-eval": 0,
     "no-new-wrappers": 0,
     "no-array-constructor": 0,
     "no-new-object": 0,

--- a/bench/index.js
+++ b/bench/index.js
@@ -66,8 +66,8 @@ try {
 }
 try {
   fixtures['generator func (differing) '] = [
-    eval('function * generator() {}; generator'), // eslint-disable-line no-eval
-    eval('function * generator() {}; generator'), // eslint-disable-line no-eval
+    eval('(function* () {})'),
+    eval('(function* () {})'),
     false,
   ];
 } catch (error) {

--- a/bench/index.js
+++ b/bench/index.js
@@ -57,8 +57,8 @@ var fixtures = {
 };
 try {
   fixtures['arrow function (differing) '] = [
-    eval('() => {}'), // eslint-disable-line no-eval
-    eval('() => {}'), // eslint-disable-line no-eval
+    eval('() => {}'),
+    eval('() => {}'),
     false,
   ];
 } catch (error) {

--- a/bench/index.js
+++ b/bench/index.js
@@ -78,7 +78,7 @@ function prepareBenchMark(test, name, assert) {
   assert = assert || deepEql;
   var leftHand = test[0];
   var rightHand = test[1];
-  var expectedResult = Boolean(2 in test ? test[2] : true);
+  var expectedResult = 2 in test ? test[2] : true;
   var invocationString = 'deepEql(' + inspect(leftHand) + ', ' + inspect(rightHand) + ') === ' + expectedResult;
   benches.push(new Benchmark(name, {
     fn: function () {

--- a/index.js
+++ b/index.js
@@ -6,10 +6,6 @@
  * MIT Licensed
  */
 
-/*!
- * Module dependencies
- */
-
 var type = require('type-detect');
 function FakeMap() {
   this._key = 'chai/deep-eql__' + Math.random() + Date.now();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-/* globals Symbol: true, Uint8Array: true, WeakMap: true */
+/* globals Symbol: false, Uint8Array: false, WeakMap: false */
 /*!
  * deep-eql
  * Copyright(c) 2013 Jake Luer <jake@alogicalparadox.com>

--- a/index.js
+++ b/index.js
@@ -12,44 +12,23 @@
 
 var type = require('type-detect');
 function FakeMap() {
-  this.clear();
-}
-FakeMap.prototype = {
-  clear: function clearMap() {
-    this.keys = [];
-    this.values = [];
-    return this;
-  },
-  set: function setMap(key, value) {
-    var index = this.keys.indexOf(key);
-    if (index >= 0) {
-      this.values[index] = value;
-    } else {
-      this.keys.push(key);
-      this.values.push(value);
-    }
-    return this;
-  },
-  get: function getMap(key) {
-    return this.values[this.keys.indexOf(key)];
-  },
-  delete: function deleteMap(key) {
-    var index = this.keys.indexOf(key);
-    if (index >= 0) {
-      this.values = this.values.slice(0, index).concat(this.values.slice(index + 1));
-      this.keys = this.keys.slice(0, index).concat(this.keys.slice(index + 1));
-    }
-    return this;
-  },
-};
-
-var MemoizeMap = null;
-if (typeof WeakMap === 'function') {
-  MemoizeMap = WeakMap;
-} else {
-  MemoizeMap = FakeMap;
+  var wmKey = 'chai/deep-eql__' + Math.random() + Date.now();
+  return {
+    get: function getMap(key) {
+      return key[wmKey];
+    },
+    set: function setMap(key, value) {
+      if (!Object.isFrozen(key)) {
+        Object.defineProperty(key, wmKey, {
+          value: value,
+          configurable: true,
+        });
+      }
+    },
+  };
 }
 
+var MemoizeMap = typeof WeakMap === 'function' ? WeakMap : FakeMap;
 /*!
  * Check to see if the MemoizeMap has recorded a result of the two operands
  *

--- a/index.js
+++ b/index.js
@@ -12,21 +12,22 @@
 
 var type = require('type-detect');
 function FakeMap() {
-  var wmKey = 'chai/deep-eql__' + Math.random() + Date.now();
-  return {
-    get: function getMap(key) {
-      return key[wmKey];
-    },
-    set: function setMap(key, value) {
-      if (!Object.isFrozen(key)) {
-        Object.defineProperty(key, wmKey, {
-          value: value,
-          configurable: true,
-        });
-      }
-    },
-  };
+  this._key = 'chai/deep-eql__' + Math.random() + Date.now();
 }
+
+FakeMap.prototype = {
+  get: function getMap(key) {
+    return key[this._key];
+  },
+  set: function setMap(key, value) {
+    if (!Object.isFrozen(key)) {
+      Object.defineProperty(key, this._key, {
+        value: value,
+        configurable: true,
+      });
+    }
+  },
+};
 
 var MemoizeMap = typeof WeakMap === 'function' ? WeakMap : FakeMap;
 /*!

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rules": {
       "complexity": 0,
       "spaced-comment": 0,
+      "no-underscore-dangle": 0,
       "no-use-before-define": 0
     }
   },

--- a/test/index.js
+++ b/test/index.js
@@ -332,6 +332,13 @@ describe('Generic', function () {
         'eql({ foo: 1, bar: -> }, { foo: 1, bar: <- }) === true');
     });
 
+    it('returns true with frozen objects', function () {
+      var objectA = Object.freeze({ foo: 1 });
+      var objectB = Object.freeze({ foo: 1 });
+      assert(eql(objectA, objectB) === true,
+        'eql(Object.freeze({ foo: 1 }), Object.freeze({ foo: 1 })) === true');
+    });
+
     it('returns false with objects with deeply unequal prototypes', function () {
       var objectA = Object.create({ foo: { a: 1 } });
       var objectB = Object.create({ foo: { a: 2 } });


### PR DESCRIPTION
`FakeMap` used to be `Map` shim instead of `WeakMap`. This PR eliminates extra `indexOf` calls and reduces code size (a bit).