### PR TITLE
docs: advertise minimum supported node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@
       alt="devDependencies:?"
       src="https://img.shields.io/david/chaijs/deep-eql.svg?style=flat-square"
     />
+  </a><a href="https://github.com/nodejs/LTS#lts-schedule1">
+    <img
+      alt="Supported Node Version: 4+"
+      src="https://img.shields.io/badge/node-4+-43853d.svg?style=flat-square"
+    />
   </a>
   <br/>
   <a href="https://saucelabs.com/u/chaijs-deep-eql">


### PR DESCRIPTION
> BREAKING CHANGE:
> 
> This package no longer supports Node < 4. Please use an older version
of this package if you intend to use Node < 4.

We needed to add a `BREAKING CHANGE` commit before the next release - as we are dropping Node < 4. This does that.