### PR TITLE
feat: allow ignoring value in comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
  * MIT Licensed
  */
 
+var ANY = typeof Symbol === 'function' ? Symbol() : Math.random() + Date.now();
+
 var type = require('type-detect');
 function FakeMap() {
   this._key = 'chai/deep-eql__' + Math.random() + Date.now();
@@ -78,6 +80,7 @@ function memoizeSet(leftHandOperand, rightHandOperand, memoizeMap, result) {
 
 module.exports = deepEqual;
 module.exports.MemoizeMap = MemoizeMap;
+module.exports.ANY = ANY;
 
 /**
  * Assert deeply nested sameValue equality between two objects of any type.
@@ -113,6 +116,10 @@ function deepEqual(leftHandOperand, rightHandOperand, options) {
  * @return {Boolean|null} equal match
  */
 function simpleEqual(leftHandOperand, rightHandOperand) {
+  if (leftHandOperand === ANY || rightHandOperand === ANY) {
+    return true;
+  }
+
   // Equal references (except for Numbers) can be returned early
   if (leftHandOperand === rightHandOperand) {
     // Handle +-0 cases

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,31 @@ function describeIf(condition) {
 }
 describe('Generic', function () {
 
+  describe('ANY', function () {
+
+    it('always returns true', function () {
+      assert(eql(undefined, eql.ANY), 'eql(undefined, eql.ANY)');
+      assert(eql(null, eql.ANY), 'eql(null, eql.ANY)');
+      assert(eql(false, eql.ANY), 'eql(false, eql.ANY)');
+      assert(eql(true, eql.ANY), 'eql(true, eql.ANY)');
+      assert(eql(1, eql.ANY), 'eql(1, eql.ANY)');
+      assert(eql(1.0, eql.ANY), 'eql(1.0, eql.ANY)');
+      assert(eql(new Number(1), eql.ANY), 'eql(new Number(1), eql.ANY)');
+      assert(eql('x', eql.ANY), 'eql("x", eql.ANY)');
+      assert(eql(new String('x'), eql.ANY), 'eql(new String("x"), eql.ANY)');
+      assert(eql({ x: 1 }, eql.ANY), 'eql({ x: 1 }, eql.ANY)');
+      assert(eql([ 1, 2, 3 ], eql.ANY), 'eql([ 1, 2, 3 ], eql.ANY)');
+      assert(eql(new Object(), eql.ANY), 'eql(new Object(), eql.ANY)');
+      assert(eql(eql.ANY, eql.ANY), 'eql(eql.ANY, eql.ANY)');
+    });
+
+    it('works on deep comparisons', function () {
+      assert(eql([ 1, eql.ANY, 3 ], [ 1, 2, 3 ]), 'eql([ 1, eql.ANY, 3 ], [ 1, 2, 3 ])');
+      assert(eql([ { x: 1, y: eql.ANY } ], [ { x: 1, y: 2 } ]), 'eql([{ x: 1, y: ANY }], [{ x: 1, y: 2 }])');
+    });
+
+  });
+
   describe('strings', function () {
 
     it('returns true for same values', function () {


### PR DESCRIPTION
There are times when you don't care what value you're comparing to.

Let's say an API returns the following response:

```js
[{ id: 8873516, name: "John", age: 35 }]
```

And you care about only the name and age. Then you could do something like this:

```js
deepEqual(apiResponse, [{ id: deepEqual.ANY, name: 'John', age: 35 }]) // true;
```

This feature is heavily influenced by Python's mocking library [ANY](https://docs.python.org/3/library/unittest.mock.html#any).