### PR TITLE
ci: Use SauceLabs action to run tests in sauce labs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -42,3 +42,9 @@ jobs:
         run: npm run test
         env:
           CI: true
+        uses: saucelabs/sauce-connect-action@v2
+        with:
+            username: ${{ secrets.SAUCE_USERNAME }}
+            accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+            tunnelIdentifier: github-action-tunnel
+            scVersion: 4.6.4


### PR DESCRIPTION
I think we need to configure the GitHub action to have access to the sauce labs secrets and then everything _should_ work. I'm hoping someone that has admin rights can access the credentials and add them to the GitHub actions secrets page.