### PR TITLE
fix branch name in GitHub CI action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
The main branch name is now `main` and not `master`.