### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:chaijs/deep-eql.git"
+    "url": "https://github.com/chaijs/deep-eql.git"
   },
   "license": "MIT",
   "author": "Jake Luer <jake@alogicalparadox.com>",


### PR DESCRIPTION
## Summary\n- update the package repository URL to use HTTPS instead of the SSH-style GitHub URL\n\n## Validation\n- git diff --check\n- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'