### PR TITLE
fix repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:chaijs/deep-eql.git"
+    "url": "https://github.com/chaijs/deep-eql.git"
   },
   "license": "MIT",
   "author": "Jake Luer <jake@alogicalparadox.com>",


### PR DESCRIPTION
## Summary
- Update the package repository URL from the legacy SSH shorthand to the public HTTPS GitHub URL.

## Verification
- `npm run lint`
- `npm run test:node`
- `npm pack --dry-run --json`