### PR TITLE
fix: compare own enumerable properties on Date, RegExp, and boxed primitives

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,8 +215,10 @@ function extensiveDeepEqualByType(leftHandOperand, rightHandOperand, leftHandTyp
     case 'Number':
     case 'Boolean':
     case 'Date':
-      // If these types are their instance types (e.g. `new Number`) then re-deepEqual against their values
-      return deepEqual(leftHandOperand.valueOf(), rightHandOperand.valueOf());
+      // If these types are their instance types (e.g. `new Number`) then re-deepEqual against their values.
+      // Own enumerable properties are still compared so two instances carrying differing data are not equal.
+      return deepEqual(leftHandOperand.valueOf(), rightHandOperand.valueOf()) &&
+        objectEqual(leftHandOperand, rightHandOperand, options);
     case 'Promise':
     case 'Symbol':
     case 'function':
@@ -238,7 +240,9 @@ function extensiveDeepEqualByType(leftHandOperand, rightHandOperand, leftHandTyp
     case 'Array':
       return iterableEqual(leftHandOperand, rightHandOperand, options);
     case 'RegExp':
-      return regexpEqual(leftHandOperand, rightHandOperand);
+      // Own enumerable properties are still compared so two regexes carrying differing data are not equal.
+      return regexpEqual(leftHandOperand, rightHandOperand) &&
+        objectEqual(leftHandOperand, rightHandOperand, options);
     case 'Generator':
       return generatorEqual(leftHandOperand, rightHandOperand, options);
     case 'DataView':

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,14 @@ describe('Generic', function () {
       assert(eql('x', 'y') === false, 'eql("x", "y") === false');
     });
 
+    it('returns false for instances with different own enumerable properties', function () {
+      var strA = new String('x');
+      strA.foo = 1;
+      var strB = new String('x');
+      strB.foo = 2;
+      assert(eql(strA, strB) === false, 'eql(new String("x") {foo:1}, new String("x") {foo:2}) === false');
+    });
+
   });
 
   describe('booleans', function () {
@@ -61,6 +69,14 @@ describe('Generic', function () {
     it('returns false for different values', function () {
       assert(eql(true, false) === false, 'eql(true, false) === false');
       assert(eql(true, Boolean(false)) === false, 'eql(true, Boolean(false)) === false');
+    });
+
+    it('returns false for instances with different own enumerable properties', function () {
+      var boolA = new Boolean(true);
+      boolA.foo = 1;
+      var boolB = new Boolean(true);
+      boolB.foo = 2;
+      assert(eql(boolA, boolB) === false, 'eql(new Boolean(true) {foo:1}, new Boolean(true) {foo:2}) === false');
     });
 
   });
@@ -129,6 +145,14 @@ describe('Generic', function () {
         'eql(new Number(-Infinity), new Number(+Infinity)) === false');
     });
 
+    it('returns false for instances with different own enumerable properties', function () {
+      var numA = new Number(1);
+      numA.foo = 1;
+      var numB = new Number(1);
+      numB.foo = 2;
+      assert(eql(numA, numB) === false, 'eql(new Number(1) {foo:1}, new Number(1) {foo:2}) === false');
+    });
+
   });
 
   describe('dates', function () {
@@ -148,6 +172,14 @@ describe('Generic', function () {
         'eql(dateA, new Date(dateA.getTime() + 1)) === false');
     });
 
+    it('returns false given two dates with different own enumerable properties', function () {
+      var dateA = new Date(0);
+      dateA.foo = 1;
+      var dateB = new Date(0);
+      dateB.foo = 2;
+      assert(eql(dateA, dateB) === false, 'eql(new Date(0) {foo:1}, new Date(0) {foo:2}) === false');
+    });
+
   });
 
   describe('regexp', function () {
@@ -164,6 +196,14 @@ describe('Generic', function () {
 
     it('returns false given two regexes with different flags', function () {
       assert(eql(/^/m, /^/i) === false, 'eql(/^/m, /^/i) === false');
+    });
+
+    it('returns false given two regexes with different own enumerable properties', function () {
+      var regexpA = /x/;
+      regexpA.foo = 1;
+      var regexpB = /x/;
+      regexpB.foo = 2;
+      assert(eql(regexpA, regexpB) === false, 'eql(/x/ {foo:1}, /x/ {foo:2}) === false');
     });
 
   });


### PR DESCRIPTION
## Problem

`deep-eql` ignores own enumerable properties on `Date`, `RegExp`, and boxed-primitive (`String`/`Number`/`Boolean`) instances. Two such objects are reported deeply equal even when they carry differing own enumerable data properties.

```js
import eql from 'deep-eql';
import util from 'node:util';

const a = new Date(0); a.foo = 1;
const b = new Date(0); b.foo = 2;

eql(a, b);                      // true  (wrong)
util.isDeepStrictEqual(a, b);   // false (oracle)
```

Same for `RegExp` (`const r = /x/; r.foo = ...`) and boxed `new Number(1)` / `new String(...)` / `new Boolean(...)`.

This contradicts the documented contract in the README "Rules" section:

> All own and inherited enumerable properties are considered.

Only `Error` is documented as an exception. The control case is already correct (`eql({foo:1}, {foo:2}) === false`), which shows that only the special-cased types bypass the rule.

## Root cause

In `extensiveDeepEqualByType()`, the `String`/`Number`/`Boolean`/`Date` branch returns only the `valueOf()` comparison, and the `RegExp` branch returns only the `toString()` comparison. Both `return` before the `objectEqual()` default branch, so own enumerable properties are never compared.

## Fix

AND the type-specific value check with the existing `objectEqual()` own-enumerable-key comparison for those branches. `objectEqual()` already returns `true` when both sides have zero own enumerable keys, so plain instances are unaffected. `valueOf` / `-0` / `NaN` semantics and the documented `Error` special-case are untouched.

## Verification

Red -> green: 5 new tests (one per affected type) assert that instances with differing own enumerable properties are not equal. They fail before the fix and pass after.

Each new case was cross-checked against `node:util.isDeepStrictEqual` as an oracle, including the cases that must stay equal (same prop value, no extra props, `new Number(NaN)`, `new Date(NaN)`) and the `Error` special-case (extra own props still ignored, as documented).

Full suite green: 179 passing, 0 failing. Lint clean.
