### PR TITLE
fix: consider extra own-enumerable properties on arrays, not just indices

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,8 +235,10 @@ function extensiveDeepEqualByType(leftHandOperand, rightHandOperand, leftHandTyp
     case 'Uint32Array':
     case 'Float32Array':
     case 'Float64Array':
-    case 'Array':
       return iterableEqual(leftHandOperand, rightHandOperand, options);
+    case 'Array':
+      return iterableEqual(leftHandOperand, rightHandOperand, options) &&
+        arrayExtraKeysEqual(leftHandOperand, rightHandOperand, options);
     case 'RegExp':
       return regexpEqual(leftHandOperand, rightHandOperand);
     case 'Generator':
@@ -336,6 +338,37 @@ function iterableEqual(leftHandOperand, rightHandOperand, options) {
     }
   }
   return true;
+}
+
+/*!
+ * `iterableEqual` only compares indices 0..length-1, so an array-index own-enumerable
+ * property (own or inherited, matching `getEnumerableKeys`) is otherwise never noticed --
+ * this checks the rest, per the documented "all own and inherited enumerable properties
+ * are considered" rule.
+ *
+ * @param {Array} leftHandOperand
+ * @param {Array} rightHandOperand
+ * @param {Object} [options] (Optional)
+ * @return {Boolean} result
+ */
+function arrayExtraKeysEqual(leftHandOperand, rightHandOperand, options) {
+  var length = leftHandOperand.length;
+  function isNotArrayIndex(key) {
+    return !(/^(0|[1-9]\d*)$/.test(key) && Number(key) < length);
+  }
+
+  var leftHandKeys = getEnumerableKeys(leftHandOperand).filter(isNotArrayIndex)
+    .concat(getEnumerableSymbols(leftHandOperand));
+  var rightHandKeys = getEnumerableKeys(rightHandOperand).filter(isNotArrayIndex)
+    .concat(getEnumerableSymbols(rightHandOperand));
+
+  if (leftHandKeys.length !== rightHandKeys.length) {
+    return false;
+  }
+  if (iterableEqual(mapSymbols(leftHandKeys).sort(), mapSymbols(rightHandKeys).sort()) === false) {
+    return false;
+  }
+  return keysEqual(leftHandOperand, rightHandOperand, leftHandKeys, options);
 }
 
 /*!

--- a/test/index.js
+++ b/test/index.js
@@ -277,6 +277,21 @@ describe('Generic', function () {
       assert(eql(new Array(1), new Array(100)) === false, 'eql(new Array(1), new Array(100)) === false');
     });
 
+    it('considers extra own-enumerable properties, not just indices', function () {
+      var withExtraX1 = [ 1, 2, 3 ];
+      withExtraX1.extra = 'x';
+      var withExtraY = [ 1, 2, 3 ];
+      withExtraY.extra = 'y';
+      var withExtraX2 = [ 1, 2, 3 ];
+      withExtraX2.extra = 'x';
+
+      assert(eql(withExtraX1, withExtraY) === false,
+        'arrays with the same indices but different extra properties are not equal');
+      assert(eql(withExtraX1, withExtraX2),
+        'arrays with the same indices and the same extra properties are equal');
+      assert(eql([ 1, 2, 3 ], [ 1, 2, 3 ]), 'arrays with no extra properties are unaffected');
+    });
+
   });
 
   describe('objects', function () {


### PR DESCRIPTION
## Summary
`Array` (along with `Arguments`/TypedArrays) dispatches to `iterableEqual`, which only compares `length` and indexed values — so a non-index own-enumerable property added to an array is silently ignored:

```js
var a = [1, 2, 3]; a.extra = 'x';
var b = [1, 2, 3]; b.extra = 'y';
deepEql(a, b); // true -- but the README says otherwise
```

This contradicts the library's own documented rule (README, "Rules" section): *"All own and inherited enumerable properties are considered."*

## Changes
- `index.js`: added `arrayExtraKeysEqual`, called after `iterableEqual` for the `'Array'` case specifically. It collects own+inherited enumerable keys/symbols (via the existing `getEnumerableKeys`/`getEnumerableSymbols` helpers, matching `objectEqual`'s own approach), filters out keys that are already-covered array indices (so holes/sparse-array semantics are untouched — those still go through `iterableEqual` exactly as before), and compares whatever's left via the existing `keysEqual`.
- Scoped to `Array` only, not `Arguments`/TypedArrays — they share the same dispatch branch and likely the same gap, but I've only verified the `Array` case, so I didn't want to guess at behavior for the others (e.g. `arguments.length` is enumerable, unlike array's, which needs its own look).
- `test/index.js`: one new case confirming extra properties are compared, and that plain arrays are unaffected.

## Testing
- Full suite: 175/175 passing (up from 174).
- Confirmed the new test fails on the prior code and passes with the fix.
- Manually checked this doesn't regress holes/sparse-array behavior (`eql(new Array(3), new Array(3))` and `eql([1,,3], [1, undefined, 3])` both still return their existing values) or symbol-keyed extras (distinct symbols with the same description still compare as different keys, matching `objectEqual`'s existing symbol handling).
- `eslint` clean, aside from the same pre-existing `linebreak-style` (Windows checkout CRLF, normalizes to LF on commit) findings present with or without this change.